### PR TITLE
Enlarge the field maxOptions of TomSelect

### DIFF
--- a/static/panes/gccdump-view.js
+++ b/static/panes/gccdump-view.js
@@ -60,6 +60,7 @@ function GccDump(hub, container, state) {
         options: [],
         items: [],
         plugins: ['input_autogrow'],
+        maxOptions: 500,
     });
 
     // this is used to save internal state.


### PR DESCRIPTION
PR for https://github.com/compiler-explorer/compiler-explorer/issues/2831

I don't know any front end knowledge. So I didn't have the environment to run or test it. But this looks so reasonable.

500 is chosen, because the maximum index of passes is 331 for now (as far as I know). It should make no difference if we want to display all chosen passes.